### PR TITLE
Add adminMint to CraftedCollection

### DIFF
--- a/contracts/CraftedCollection.sol
+++ b/contracts/CraftedCollection.sol
@@ -103,6 +103,18 @@ contract CraftedCollection is
         emit Minted(msg.sender, quantity);
     }
 
+    /// @notice Mint tokens without payment. Only callable by admins.
+    /// @param to The recipient of the minted tokens.
+    /// @param quantity Number of tokens to mint.
+    function adminMint(address to, uint256 quantity) external onlyRole(ADMIN_ROLE) {
+        if (to == address(0)) revert ZeroAddress();
+        if (quantity == 0) revert InvalidToken();
+        if (totalSupply() + quantity > MAX_SUPPLY) revert MaxSupplyReached();
+
+        _safeMint(to, quantity);
+        emit Minted(to, quantity);
+    }
+
     // TRAIT MANAGEMENT
     function updateTraits(uint256 tokenId, Traits calldata newTraits) external onlyRole(CRAFTER_ROLE) {
         if (!_exists(tokenId)) revert InvalidToken();

--- a/test/CraftedCollection.js
+++ b/test/CraftedCollection.js
@@ -39,4 +39,20 @@ describe("CraftedCollection", function () {
     const traits = { code: "GEN", artVersion: "v1", metadataURI: "ipfs://" , level: 1, power: 1, rarity: 1 };
     await expect(proxy.updateTraits(0, traits)).to.emit(proxy, "TraitsUpdated");
   });
+
+  it("allows admin to mint for free", async function () {
+    const { proxy, owner, user } = await deploy();
+    await expect(proxy.connect(owner).adminMint(user.address, 1))
+      .to.emit(proxy, "Minted")
+      .withArgs(user.address, 1);
+    expect(await proxy.totalSupply()).to.equal(1);
+  });
+
+  it("prevents non-admin from calling adminMint", async function () {
+    const { proxy, user } = await deploy();
+    await expect(proxy.connect(user).adminMint(user.address, 1)).to.be.revertedWithCustomError(
+      proxy,
+      "AccessControlUnauthorizedAccount"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add `adminMint` for free team minting
- test admin and unauthorized minting

## Testing
- `npx hardhat test` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6858e13baaac8320b32102145303fd89