### PR TITLE
Add updatable name/symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@ npx hardhat run --network base --script "(await ethers.getContractFactory('Craft
 
 or update the wallet cap similarly using `setMaxWalletHoldings`.
 
-3. **Reveal Metadata** – once artwork is ready, run `setBaseURI` again with the final metadata location.
+3. **Rename Collection** – change the name or ticker after deployment:
 
-4. **Withdraw Funds** – the `withdraw` script sends contract balance to the recipient wallet set in the script. Update `scripts/withdraw.js` with your treasury address.
+```shell
+npx hardhat run --network base --script "(await ethers.getContractFactory('CraftedCollection')).attach('<proxy>').setCollectionDetails('New Name','NEW')"
+```
+4. **Reveal Metadata** – once artwork is ready, run `setBaseURI` again with the final metadata location.
+
+5. **Withdraw Funds** – the `withdraw` script sends contract balance to the recipient wallet set in the script. Update `scripts/withdraw.js` with your treasury address.
 
 ## Running Tests
 

--- a/contracts/CraftedCollection.sol
+++ b/contracts/CraftedCollection.sol
@@ -30,6 +30,8 @@ contract CraftedCollection is
     uint256 public maxWalletHoldings;
 
     string private _baseTokenURI;
+    string private _collectionName;
+    string private _collectionSymbol;
 
     struct Traits {
         string code;
@@ -61,6 +63,7 @@ contract CraftedCollection is
     event CraftingInitialized();
     event MintPriceUpdated(uint256 newPrice);
     event MaxWalletHoldingsUpdated(uint256 newLimit);
+    event CollectionDetailsUpdated(string newName, string newSymbol);
     event Received(address indexed sender, uint256 amount);
 
     function supportsInterface(bytes4 interfaceId)
@@ -79,6 +82,9 @@ contract CraftedCollection is
         __ReentrancyGuard_init();
         __ERC2981_init();
         __UUPSUpgradeable_init();
+
+        _collectionName = name_;
+        _collectionSymbol = symbol_;
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(ADMIN_ROLE, msg.sender);
@@ -160,6 +166,20 @@ contract CraftedCollection is
     function setMaxWalletHoldings(uint256 newLimit) external onlyRole(ADMIN_ROLE) {
         maxWalletHoldings = newLimit;
         emit MaxWalletHoldingsUpdated(newLimit);
+    }
+
+    function setCollectionDetails(string calldata newName, string calldata newSymbol) external onlyRole(ADMIN_ROLE) {
+        _collectionName = newName;
+        _collectionSymbol = newSymbol;
+        emit CollectionDetailsUpdated(newName, newSymbol);
+    }
+
+    function name() public view override returns (string memory) {
+        return _collectionName;
+    }
+
+    function symbol() public view override returns (string memory) {
+        return _collectionSymbol;
     }
 
     function tokenURI(uint256 tokenId)

--- a/scripts/setCollectionDetails.js
+++ b/scripts/setCollectionDetails.js
@@ -1,0 +1,18 @@
+const { ethers } = require('hardhat')
+
+async function main() {
+  const proxyAddress = '0x2e51a8FdC067e415CFD5d00b9add5C6Af72d676c'
+  const newName = 'Crafted Collection'
+  const newSymbol = 'CRAFT'
+
+  const CraftedCollection = await ethers.getContractFactory('CraftedCollection')
+  const contract = await CraftedCollection.attach(proxyAddress)
+
+  await contract.setCollectionDetails(newName, newSymbol)
+  console.log(`✅ Collection updated to ${newName} (${newSymbol})`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/test/CraftedCollection.js
+++ b/test/CraftedCollection.js
@@ -55,4 +55,11 @@ describe("CraftedCollection", function () {
       "AccessControlUnauthorizedAccount"
     );
   });
+
+  it("updates collection name and symbol", async function () {
+    const { proxy, owner } = await deploy();
+    await proxy.connect(owner).setCollectionDetails("New Name", "NEW");
+    expect(await proxy.name()).to.equal("New Name");
+    expect(await proxy.symbol()).to.equal("NEW");
+  });
 });


### PR DESCRIPTION
## Summary
- support changing the collection name or ticker
- expose helper script for updating the collection details
- document how to rename collection after deployment
- test name and symbol change logic

## Testing
- `npx hardhat test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6858f39317488320ae9f8a4d11bfb7eb