### PR TITLE
Fix override spec for collection name/symbol

### DIFF
--- a/contracts/CraftedCollection.sol
+++ b/contracts/CraftedCollection.sol
@@ -174,11 +174,21 @@ contract CraftedCollection is
         emit CollectionDetailsUpdated(newName, newSymbol);
     }
 
-    function name() public view override returns (string memory) {
+    function name()
+        public
+        view
+        override(ERC721AUpgradeable, IERC721AUpgradeable)
+        returns (string memory)
+    {
         return _collectionName;
     }
 
-    function symbol() public view override returns (string memory) {
+    function symbol()
+        public
+        view
+        override(ERC721AUpgradeable, IERC721AUpgradeable)
+        returns (string memory)
+    {
         return _collectionSymbol;
     }
 


### PR DESCRIPTION
## Summary
- specify ERC721A overrides for `name()` and `symbol()`

## Testing
- `npx hardhat compile` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6858f512923c83209db017b47d67c8a3