### PR TITLE
Add full suite of Hardhat CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ npx hardhat test
 npx hardhat run scripts/deploy.js --network <network>
 ```
 
+### CLI scripts
+
+- `adminMint.js` – mint tokens as an admin without payment
+- `freezeMetadata.js` – permanently lock metadata for a token
+- `getTraits.js` – view the on-chain traits for a token
+- `grantRole.js` – grant roles such as `CRAFTER_ROLE`
+- `mint.js` – mint tokens from the CLI
+- `pause.js`/`unpause.js` – pause or resume minting
+- `setBaseURI.js` – set the base metadata URI
+- `setCollectionDetails.js` – rename the collection
+- `setMaxWalletHoldings.js` – update the wallet holding limit
+- `setMintPrice.js` – change the mint price
+- `setRoyaltyInfo.js` – configure royalties
+- `updateMetadata.js` – update a token metadata URI
+- `updateTraits.js` – modify token traits
+- `upgrade.js` – upgrade the implementation
+- `withdraw.js` – withdraw contract balance
+
 The Hardhat config enables the Solidity optimizer with 100 runs to keep the
 contract bytecode small enough for mainnet deployment. No additional steps are
 required when compiling.

--- a/scripts/adminMint.js
+++ b/scripts/adminMint.js
@@ -1,0 +1,18 @@
+const { ethers } = require('hardhat')
+
+async function main() {
+  const proxyAddress = '0x76065074344824a3201E46b84FA6611384bD7E92'
+  const recipient = '0xfd0dF1cb53a9F4576D899C275928999fc73e78E1'
+  const quantity = 1
+
+  const MadeForRats = await ethers.getContractFactory('MadeForRats')
+  const contract = await MadeForRats.attach(proxyAddress)
+
+  await contract.adminMint(recipient, quantity)
+  console.log(`✅ Admin minted ${quantity} token(s) to ${recipient}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/freezeMetadata.js
+++ b/scripts/freezeMetadata.js
@@ -1,0 +1,17 @@
+const { ethers } = require('hardhat')
+
+async function main() {
+  const proxyAddress = '0x76065074344824a3201E46b84FA6611384bD7E92'
+  const tokenId = 1
+
+  const MadeForRats = await ethers.getContractFactory('MadeForRats')
+  const contract = await MadeForRats.attach(proxyAddress)
+
+  await contract.freezeMetadata(tokenId)
+  console.log(`✅ Metadata frozen for token ${tokenId}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/getTraits.js
+++ b/scripts/getTraits.js
@@ -1,0 +1,17 @@
+const { ethers } = require('hardhat')
+
+async function main() {
+  const proxyAddress = '0x76065074344824a3201E46b84FA6611384bD7E92'
+  const tokenId = 1
+
+  const MadeForRats = await ethers.getContractFactory('MadeForRats')
+  const contract = await MadeForRats.attach(proxyAddress)
+
+  const traits = await contract.getTraits(tokenId)
+  console.log(`Traits for token ${tokenId}:`, traits)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/setMaxWalletHoldings.js
+++ b/scripts/setMaxWalletHoldings.js
@@ -1,0 +1,17 @@
+const { ethers } = require('hardhat')
+
+async function main() {
+  const proxyAddress = '0x76065074344824a3201E46b84FA6611384bD7E92'
+  const newLimit = 3
+
+  const MadeForRats = await ethers.getContractFactory('MadeForRats')
+  const contract = await MadeForRats.attach(proxyAddress)
+
+  await contract.setMaxWalletHoldings(newLimit)
+  console.log(`✅ Wallet limit set to ${newLimit}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/setMintPrice.js
+++ b/scripts/setMintPrice.js
@@ -1,0 +1,17 @@
+const { ethers } = require('hardhat')
+
+async function main() {
+  const proxyAddress = '0x76065074344824a3201E46b84FA6611384bD7E92'
+  const newPrice = ethers.parseEther('0.05')
+
+  const MadeForRats = await ethers.getContractFactory('MadeForRats')
+  const contract = await MadeForRats.attach(proxyAddress)
+
+  await contract.setMintPrice(newPrice)
+  console.log(`✅ Mint price set to ${ethers.formatEther(newPrice)} ETH`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/setRoyaltyInfo.js
+++ b/scripts/setRoyaltyInfo.js
@@ -1,0 +1,18 @@
+const { ethers } = require('hardhat')
+
+async function main() {
+  const proxyAddress = '0x76065074344824a3201E46b84FA6611384bD7E92'
+  const receiver = '0xfd0dF1cb53a9F4576D899C275928999fc73e78E1'
+  const feeNumerator = 500 // 5%
+
+  const MadeForRats = await ethers.getContractFactory('MadeForRats')
+  const contract = await MadeForRats.attach(proxyAddress)
+
+  await contract.setRoyaltyInfo(receiver, feeNumerator)
+  console.log('✅ Royalty info updated.')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/updateMetadata.js
+++ b/scripts/updateMetadata.js
@@ -1,0 +1,18 @@
+const { ethers } = require('hardhat')
+
+async function main() {
+  const proxyAddress = '0x76065074344824a3201E46b84FA6611384bD7E92'
+  const tokenId = 1
+  const metadataURI = 'ipfs://Qm...'
+
+  const MadeForRats = await ethers.getContractFactory('MadeForRats')
+  const contract = await MadeForRats.attach(proxyAddress)
+
+  await contract.updateMetadata(tokenId, metadataURI)
+  console.log(`✅ Metadata updated for token ${tokenId}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add adminMint.js for admin controlled minting
- add scripts to update and freeze metadata
- add scripts for royalties, mint price, wallet limits and trait reads
- document all available CLI scripts in the README

## Testing
- `npx hardhat test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6859e113f6508320ba29289d3c3f87da