### PR TITLE
Add OpenSea metadata refresh helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ npx hardhat run scripts/deploy.js --network <network>
 - `updateTraits.js` – modify token traits
 - `upgrade.js` – upgrade the implementation
 - `withdraw.js` – withdraw contract balance
+- `refreshOpenSea.js` – request a metadata refresh on OpenSea
 
 The Hardhat config enables the Solidity optimizer with 100 runs to keep the
 contract bytecode small enough for mainnet deployment. No additional steps are
@@ -72,8 +73,8 @@ npx hardhat run --network base --script "(await ethers.getContractFactory('MadeF
 ```
 
 4. **Reveal Metadata** – once artwork is ready, run `setBaseURI` again with the final metadata location.
-
 5. **Withdraw Funds** – the `withdraw` script sends contract balance to the recipient wallet set in the script. Update `scripts/withdraw.js` with your treasury address.
+6. **Refresh Metadata on OpenSea** – after changing a token URI, run `node scripts/refreshOpenSea.js` to clear the cache.
 
 ## Running Tests
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@openzeppelin/contracts": "^5.0.1",
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "dotenv": "^16.3.1",
-    "erc721a": "^4.2.3"
+    "erc721a": "^4.2.3",
+    "@api/opensea": "^1.0.0"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",

--- a/scripts/refreshOpenSea.js
+++ b/scripts/refreshOpenSea.js
@@ -1,0 +1,22 @@
+const opensea = require('@api/opensea')
+
+async function main() {
+  const chain = 'base'
+  const contractAddress = '0x76065074344824a3201E46b84FA6611384bD7E92'
+  const tokenId = '1'
+
+  opensea.server('https://api.opensea.io')
+
+  const { data } = await opensea.refresh_nft({
+    chain,
+    address: contractAddress,
+    identifier: tokenId,
+  })
+
+  console.log('✅ Refresh request submitted:', data)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add a script to request a metadata refresh from OpenSea using `@api/opensea`
- document the refresh script and how to run it
- include `@api/opensea` as a dependency

## Testing
- `npx hardhat test` *(fails: 403 Forbidden while downloading packages)*


------
https://chatgpt.com/codex/tasks/task_e_685ba943e0f48320a4c58c8bd9a70281